### PR TITLE
build: pin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dependencies = [
     "biopython",
     "tqdm",
     "click",
-    "cool-seq-tool>=0.4.0.dev1",
-    "ga4gh.vrs~=2.0.0-a6",
+    "cool-seq-tool==0.4.0.dev3",
+    "ga4gh.vrs==2.0.0-a6",
     # probably easiest to just include pg dependency group even if it's not always necessary
-    "gene-normalizer[pg]>=0.3.0-dev1",
-    "pydantic>=2",
+    "gene-normalizer[pg]==0.3.0-dev1",
+    "pydantic~=2.0",
     "python-dotenv",
     "setuptools>=68.0",  # tmp -- ensure 3.12 compatibility
 ]


### PR DESCRIPTION
We've added some breaking changes in a few of the dependencies -- pinning now to keep it safe but we should update to match the new interface features