### PR TITLE
feat!: Use VRS 2.0 models as primary output

### DIFF
--- a/temp_example.json
+++ b/temp_example.json
@@ -1,0 +1,129 @@
+{
+    "pre_mapped": {
+        "id": "ga4gh:VA.FLe4-pSUs7vjdVtVD4TmUNL4JhrBbqTd",
+        "type": "Allele",
+        "extensions": [
+            {
+                "name": "vrs_ref_allele_seq",
+                "value": "Y"
+            }
+        ],
+        "digest": "FLe4-pSUs7vjdVtVD4TmUNL4JhrBbqTd",
+        "location": {
+            "type": "SequenceLocation",
+            "digest": "DCfpyPamywb6xZ_YuqheLIUUna9idFdK",
+            "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.PyX9IDu95_tYLg1Jz9JpW5xpQkwn6bpB"
+            },
+            "start": 169,
+            "end": 170
+        },
+        "state": {
+            "type": "LiteralSequenceExpression",
+            "sequence": "G"
+        }
+    },
+    "post_mapped": {
+        "id": "ga4gh:VA.rKyjzmt0czvrVFeRsvCxH-aE4GSoMzUS",
+        "type": "Allele",
+        "extensions": [
+            {
+                "name": "vrs_ref_allele_seq",
+                "value": "Y"
+            }
+        ],
+        "digest": "rKyjzmt0czvrVFeRsvCxH-aE4GSoMzUS",
+        "expressions": [
+            {
+                "syntax": "hgvs.p",
+                "value": "NP_938033.1:p.Tyr439Gly"
+            }
+        ],
+        "location": {
+            "type": "SequenceLocation",
+            "digest": "F_PJZIrk2lQaj2CLaS-TbsWdeJjwAsCu",
+            "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.uJDQo_HaTNFL2-0-6K5dVzVcweigexye"
+            },
+            "start": 438,
+            "end": 439
+        },
+        "state": {
+            "type": "LiteralSequenceExpression",
+            "sequence": "G"
+        }
+    },
+    "pre_mapped_1_3": {
+        "id": "ga4gh:VA.Y431PxDyuuhO3PO49FclwzGlAj5etzYT",
+        "type": "VariationDescriptor",
+        "variation": {
+            "type": "Allele",
+            "id": "ga4gh:VA.Y431PxDyuuhO3PO49FclwzGlAj5etzYT",
+            "location": {
+                "id": "ga4gh:VSL.PibXoE1muL7g3Nfsw3DGR_abitFQ4TwS",
+                "type": "SequenceLocation",
+                "sequence_id": "ga4gh:SQ.PyX9IDu95_tYLg1Jz9JpW5xpQkwn6bpB",
+                "interval": {
+                    "type": "SequenceInterval",
+                    "start": {
+                        "type": "Number",
+                        "value": 169
+                    },
+                    "end": {
+                        "type": "Number",
+                        "value": 170
+                    }
+                }
+            },
+            "state": {
+                "type": "LiteralSequenceExpression",
+                "sequence": "G"
+            }
+        },
+        "expressions": [],
+        "vrs_ref_allele_seq": "Y",
+        "extensions": []
+    },
+    "post_mapped_1_3": {
+        "id": "ga4gh:VA.pD0aYcizlb104FS6Svb3eCyjoRPIkGWH",
+        "type": "VariationDescriptor",
+        "variation": {
+            "type": "Allele",
+            "id": "ga4gh:VA.pD0aYcizlb104FS6Svb3eCyjoRPIkGWH",
+            "location": {
+                "id": "ga4gh:VSL._pyMvj1qUhoEiuWUa7vVloeBv0qfNhXM",
+                "type": "SequenceLocation",
+                "sequence_id": "ga4gh:SQ.uJDQo_HaTNFL2-0-6K5dVzVcweigexye",
+                "interval": {
+                    "type": "SequenceInterval",
+                    "start": {
+                        "type": "Number",
+                        "value": 438
+                    },
+                    "end": {
+                        "type": "Number",
+                        "value": 439
+                    }
+                }
+            },
+            "state": {
+                "type": "LiteralSequenceExpression",
+                "sequence": "G"
+            }
+        },
+        "expressions": [
+            {
+                "type": "Expression",
+                "syntax": "hgvs.p",
+                "value": "NP_938033.1:p.Tyr439Gly"
+            }
+        ],
+        "vrs_ref_allele_seq": "Y",
+        "extensions": []
+    },
+    "mavedb_id": "urn:mavedb:00000041-a-1#36",
+    "relation": "SO:is_homologous_to",
+    "score": 0.753146338
+}


### PR DESCRIPTION
* Elevate VRS 2 variations to primary output. Can still also optionally provide 1.3 alleles.
* Use `CisPhasedBlock` instead of `Haplotype`
* Use VRS 2.0a methods for generating VRS 1.3 IDs rather than internal method
* Update other dependencies