### PR TITLE
fix: perform appropriate cleanup after seqrepo check

### DIFF
--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -405,6 +405,8 @@ def check_seqrepo() -> None:
     except sqlite3.Error as e:
         _logger.error("SeqRepo sequences DB isn't writeable.")
         raise DataLookupError from e
+    # delete the CST instance so that future calls are made against an open SeqAlias
+    # connection, since we close it above
     del CoolSeqToolBuilder.instance
 
 

--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -405,6 +405,7 @@ def check_seqrepo() -> None:
     except sqlite3.Error as e:
         _logger.error("SeqRepo sequences DB isn't writeable.")
         raise DataLookupError from e
+    del CoolSeqToolBuilder.instance
 
 
 def get_chromosome_identifier(chromosome: str) -> str:


### PR DESCRIPTION
Checking SeqRepo status would close the SeqAlias DB but keep the rest of SeqRepo --
this meant subsequent calls were made on a closed connection. This closes the entire
CST object instead.
