### PR TITLE
Correct alignment logic, ensure proper variant selection for post-mapped genomic variants

### DIFF
--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -489,7 +489,7 @@ def get_sequence(
 # -------------------------------- VRS-Python -------------------------------- #
 
 
-def translate_hgvs_to_vrs(hgvs: str) -> Allele:
+def translate_hgvs_to_vrs(hgvs: str) -> Allele | None:
     """Convert HGVS variation description to VRS object.
 
     :param hgvs: MAVE-HGVS variation string
@@ -500,7 +500,11 @@ def translate_hgvs_to_vrs(hgvs: str) -> Allele:
         hgvs = hgvs.replace(":c.", ":g.")
 
     tr = TranslatorBuilder(get_seqrepo())
-    allele: Allele = tr.translate_from(hgvs, "hgvs", do_normalize=False)
+    try:
+        allele: Allele = tr.translate_from(hgvs, "hgvs", do_normalize=False)
+    except ValueError as warn:
+        _logger.warning(warn)
+        return None
 
     if (
         not isinstance(allele.location, SequenceLocation)

--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -288,7 +288,7 @@ def get_normalized_gene_response(
             return gene_descriptor
 
     # try taking the first word in the target name
-    if metadata.target_gene_name:
+    if metadata.target_gene_name and "Minigene" not in metadata.target_gene_name:
         parsed_name = ""
         if "_" in metadata.target_gene_name:
             parsed_name = metadata.target_gene_name.split("_")

--- a/src/dcd_mapping/schemas.py
+++ b/src/dcd_mapping/schemas.py
@@ -145,7 +145,7 @@ class MappedScore(BaseModel):
     annotation_layer: AnnotationLayer
     score: str | None
     pre_mapped: Allele | CisPhasedBlock
-    post_mapped: Allele | CisPhasedBlock
+    post_mapped: Allele | CisPhasedBlock | None
 
 
 class ScoreAnnotation(BaseModel):

--- a/src/dcd_mapping/vrs_map.py
+++ b/src/dcd_mapping/vrs_map.py
@@ -267,7 +267,7 @@ def _map_protein_coding(
             align_result,
             False,
         )
-        if pre_mapped_genomic is None or post_mapped_genomic is None:
+        if pre_mapped_genomic is None and post_mapped_genomic is None:
             _logger.warning(
                 "Encountered apparently invalid genomic variants in %s: %s",
                 row.accession,
@@ -330,7 +330,7 @@ def _map_regulatory_noncoding(
             False,
             offset=0,
         )
-        if not pre_map_allele or not post_map_allele:
+        if not pre_map_allele and not post_map_allele:
             msg = "Genomic variations missing"
             raise VrsMapError(msg)
         variations.append(
@@ -462,14 +462,10 @@ def _get_variation(
         allele.id = ga4gh_identify(allele)
 
         # Check if the start of an allele is covered by the alignment block for
-        # genomic variants
+        # post-mapped genomic variants
         if layer == AnnotationLayer.GENOMIC:
             if pre_map:
-                if (
-                    allele.location.start >= alignment.query_range.start
-                    and allele.location.start < alignment.query_range.end
-                ):
-                    alleles.append(allele)
+                alleles.append(allele)
             else:
                 if (
                     allele.location.start >= alignment.hit_range.start

--- a/src/dcd_mapping/vrs_map.py
+++ b/src/dcd_mapping/vrs_map.py
@@ -393,6 +393,8 @@ def _get_variation(
     for hgvs_string in hgvs_strings:
         # Generate VRS Allele structure. Set VA digests and SL digests to None
         allele = translate_hgvs_to_vrs(hgvs_string)
+        if allele is None:
+            break
         allele.id = None
         allele.digest = None
         allele.location.id = None


### PR DESCRIPTION
closes #69 

- Corrects alignment logic. For targets with gene symbols, a `BlatOutput` tuple is constructed containing the hsp object, the distance between the start of the alignment and the gene start, and the coverage of the alignment. The list of tuples is first sorted by increasing distance. Then, hsp objects with the same distance are grouped together, and sorted in descending order by coverage. This results in the best candidate alignment appearing at the top of the list
- Ensures that only post-mapped genomic variants whose positions are known are mapped. All pre-mapped genomic variants are included as their positions are described with respect to the MAVE target sequence.

Question to consider: If we have different sized lists for the pre-mapped and post-mapped variants, how can we determine which post-mapped variant belongs to its corresponding pre-mapped variant. This metric is needed to compute the reference sequence match percentage.