### PR TITLE
fix: Update alignment and annotation functionality

### DIFF
--- a/src/dcd_mapping/annotate.py
+++ b/src/dcd_mapping/annotate.py
@@ -337,8 +337,10 @@ def _annotate_cpb_mapping(
         post_mapped.extensions = [
             Extension(name="vrs_v1.3_id", value=_get_vrs_1_3_haplotype_id(post_mapped)),
         ]
-    else:
+    elif len(post_mapped.members) == 1:
         post_mapped = post_mapped.members[0]
+    else:
+        post_mapped = None
 
     namespace = metadata.urn
     val = mapping.accession_id.split("#")[1]

--- a/src/dcd_mapping/vrs_map.py
+++ b/src/dcd_mapping/vrs_map.py
@@ -441,7 +441,11 @@ def _get_variation(
                         allele.location.end = allele.location.start + diff2
                         if "dup" in hgvs_string:
                             allele.state.sequence = SequenceString(
-                                2 * _get_allele_sequence(allele)
+                                str(
+                                    Seq(
+                                        2 * _get_allele_sequence(allele)
+                                    ).reverse_complement()
+                                )
                             )
                         temp_str = str(
                             Seq(str(allele.state.sequence.root)).reverse_complement()


### PR DESCRIPTION
I had been checking over the mapping code and wanted to make some changes to `align.py` and `annotate.py`. There are a lot of different edge cases to consider when thinking about how a MAVE sequence aligns to the human genome, but I think our current logic performs well, especially when the MAVE sequence is not heavily mutagenized or the human reference sequence does not consist solely of tandem repeats (e.g. [UBB](https://services.genomicmedlab.org/seqrepo/1/sequence/refseq%3ANP_061828.1)).

- It turns out we can run BLAT locally if the target sequence is over 25,000 nucleotides long. For example, mapping is successful for score set [1213-a-1](https://mavedb.org/score-sets/urn:mavedb:00001213-a-1). I removed the logic that checked for sequence length.
- When annotating CisPhasedBlocks, we need to check that the number of mapped variants that fall in the sequence alignment is 1
- We should consider the strandedness of the BLAT HSP object when computing the distance from the start (i.e. CDS start position